### PR TITLE
HTTPのエラーハンドリングを追加した

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .bitrise*
 .gows.user.yml
 tmp/
+_tmp/

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -33,7 +33,7 @@ workflows:
         run_if: true
         inputs:
         - api_key: $API_KEY
-        - build_path: $BUILD_PATH
+        - build_path: ~/Downloads/sportslab_app.app
 
   # ----------------------------------------------------------------
   # --- workflows to Share this step into a Step Library


### PR DESCRIPTION
エラーハンドリングを追加して、アップロードの失敗とAPIの認証の失敗をフィードバックするようにした。